### PR TITLE
adds signMessage method

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -65,7 +65,9 @@ export default {
   // globalTeardown: undefined,
 
   // A set of global variables that need to be available in all test environments
-  // globals: {},
+  globals: {
+    Uint8Array: Uint8Array,
+  },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jest-environment-jsdom": "^28.1.3",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
+    "tweetnacl": "^1.0.3",
     "typescript": "^4.7.4"
   },
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   Transaction,
   TransactionSignature,
 } from "@solana/web3.js";
+import nacl from "tweetnacl";
 
 interface E2EWalletEvents {
   connect(...args: unknown[]): unknown;
@@ -134,9 +135,13 @@ export class E2EWalletAdapter extends BaseWalletAdapter {
     transactions: Transaction[]
   ): Promise<Transaction[]> {
     this._checkForReject();
-    for (let i=0; i < transactions.length; i++) {
+    for (let i = 0; i < transactions.length; i++) {
       transactions[i].sign(this._underlyingWallet);
     }
     return transactions;
+  }
+
+  async signMessage(message: Uint8Array): Promise<Uint8Array> {
+    return nacl.sign.detached(message, this._underlyingWallet.secretKey);
   }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,8 @@
 import { Keypair, PublicKey, Transaction, Connection } from "@solana/web3.js";
 import { E2EWalletAdapter, E2EWindow } from "../src/index";
+import nacl from "tweetnacl";
+import bs58 from "bs58";
+import { TextEncoder } from "util";
 
 describe("E2EWalletAdapter", () => {
   const connection = new Connection("https://api.devnet.solana.com");
@@ -127,5 +130,19 @@ describe("E2EWalletAdapter", () => {
       [adapter._underlyingWallet]
     );
     expect(signatureTwo).toBe("test-signature");
+  });
+
+  it("should be able to sign a message", async () => {
+    const config = { keypair: new Keypair() };
+    const adapter = new E2EWalletAdapter(config);
+    adapter.connect();
+    const message = new TextEncoder().encode("test message");
+    const signature = await adapter.signMessage(message);
+    const verified = nacl.sign.detached.verify(
+      message,
+      signature,
+      bs58.decode(config.keypair.publicKey.toBase58())
+    );
+    expect(verified).toBe(true);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4976,7 +4976,7 @@ tslib@^2.3.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
-tweetnacl@^1.0.0:
+tweetnacl@^1.0.0, tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==


### PR DESCRIPTION
Hey there! I just added the "signMessage" method to the E2EWalletAdapter to allows us to run our Cypress end-to-end (E2E) tests. I tried it on our tests and it works without any issues.
I also just added a unit test and and everything passes with flying colors.
Please give it a look and let me know if you would like me to change anything.